### PR TITLE
Breaking: Refactor query builder

### DIFF
--- a/docs/source/queries.md
+++ b/docs/source/queries.md
@@ -87,29 +87,35 @@ Adding parameter blocks to your command by using [param_block()](<tsbot.query_bu
 This works much like [params()](<tsbot.query_builder.TSQuery.params()>), but you can add multiple **_values_** to a given **_key_**.
 
 This can be handy when a command allows you to specify multiple targets.
-For example command `clientmove` allows you to specify multiple `clid`'s to move.
+For example command `clientmove` lets you move multiple `clid`'s at the same time.
 
 ```
 from tsbot import query
 
 example_query = query("clientmove")
-example_query.params(cid=1)        # Set the channel where to move clients
-example_query.param_block(clid=2)  # Selecting client_id #2 to be moved
-example_query.param_block(clid=3)  # Selecting client_id #3 to be moved
-example_query.param_block(clid=6)  # Selecting client_id #6 to be moved
+example_query = example_query.params(cid=1)        # Set the channel where to move clients
+example_query = example_query.param_block(clid=2)  # Selecting client_id #2 to be moved
+example_query = example_query.param_block(clid=3)  # Selecting client_id #3 to be moved
+example_query = example_query.param_block(clid=6)  # Selecting client_id #6 to be moved
 ```
 
 ````{warning}
 Each parameter block has to be a new call to [param_block()](<tsbot.query_builder.TSQuery.param_block()>).
 For example you **cannot** do this:
 ```
-example_query.param_block(clid=2, clid=3, clid=6)
+example_query = example_query.param_block(clid=2, clid=3, clid=6)
 ```
 ````
 
-### Method cascading
+```{info}
+You can use an iterable of [dict](dict)[[str](str), [str](str)] as the first argument to pass multiple
+parameter blocks at the same time.
+```
 
-Method cascading allows you to make multiple method calls to a `TSQuery` object.  
+
+### Method chaining
+
+Method chaining allows you to make multiple method calls to a `TSQuery` object.  
 You can mix and match the order of these calls, this will still compile to a suitable result.
 
 ```
@@ -175,8 +181,8 @@ In this example we can see that you could add parameters to the {{TSQuery}} obje
 from tsbot import query
 
 clientdbfind_query = query("clientdbfind")
-clientdbfind_query.params(pattern="FPMPSC6MXqXq751dX7BKV0JniSo")
-clientdbfind_query.option("uid")
+clientdbfind_query = clientdbfind_query.params(pattern="FPMPSC6MXqXq751dX7BKV0JniSo")
+clientdbfind_query = clientdbfind_query.option("uid")
 
 # ---- OR ----
 
@@ -195,19 +201,19 @@ Goal:
 `clientkick reasonid=5 reasonmsg=Go\saway! clid=1|clid=2|clid=3`
 
 In this example adding parameter blocks to queries can be achieved multiple ways.
-Either using normal **_for loops_** or one-liner **_list comprehension_**.
+Either using **_for loops_** or passing an iterable as the first argument.
 
 ```
 from tsbot import query
 
 clientkick_query = query("clientkick").params(reasonid=5, reasonmsg="Go away!")
 for client_id in (1, 2, 3):
-    clientkick_query.param_block(clid=client_id)
+    clientkick_query = clientkick_query.param_block(clid=client_id)
 
 # ---- OR ----
 
 clientkick_query = query("clientkick").params(reasonid=5, reasonmsg="Go away!")
-[clientkick_query.param_block(clid=client_id) for client_id in (1, 2, 3)]
+clientkick_query = clientkick_query.param_block(({"clid": client_id}) for client_id in (1, 2, 3))
 
 print(clientkick_query.compile()) # clientkick reasonid=5 reasonmsg=Go\saway! clid=1|clid=2|clid=3
 ```
@@ -223,8 +229,8 @@ In this example we can see that parameter blocks can have multiple parameters at
 from tsbot import query
 
 clientaddperm_query = query("clientaddperm").params(cldbid=16)
-clientaddperm_query.param_block(permid=17276, permvalue=50, permskip=1)
-clientaddperm_query.param_block(permid=21415, permvalue=20, permskip=0)
+clientaddperm_query = clientaddperm_query.param_block(permid=17276, permvalue=50, permskip=1)
+clientaddperm_query = clientaddperm_query.param_block(permid=21415, permvalue=20, permskip=0)
 
 print(clientaddperm_query.compile()) # clientaddperm cldbid=16 permid=17276 permvalue=50 permskip=1|permid=21415 permvalue=20 permskip=0
 ```

--- a/docs/source/queries.md
+++ b/docs/source/queries.md
@@ -87,7 +87,7 @@ Adding parameter blocks to your command by using [param_block()](<tsbot.query_bu
 This works much like [params()](<tsbot.query_builder.TSQuery.params()>), but you can add multiple **_values_** to a given **_key_**.
 
 This can be handy when a command allows you to specify multiple targets.
-For example command `clientmove` lets you move multiple `clid`'s at the same time.
+For example command `clientmove` lets you to move multiple `clid`'s at the same time.
 
 ```
 from tsbot import query

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from tsbot.query_builder import TSQuery, query
 
 # pyright: reportPrivateUsage=false
@@ -10,7 +11,7 @@ def test_add_options():
     q = query("channellist")
     assert q._options == []
 
-    q.option("topic", "flags", "voice")
+    q = q.option("topic", "flags", "voice")
     assert q._options == ["topic", "flags", "voice"]
 
 
@@ -18,19 +19,41 @@ def test_add_params():
     q = query("channelmove")
     assert q._parameters == {}
 
-    q.params(cid=16, cpid=1, order=0)
+    q = q.params(cid=16, cpid=1, order=0)
     assert q._parameters == {"cid": "16", "cpid": "1", "order": "0"}
 
 
-def test_app_param_blocks():
+def test_add_param_blocks():
     q = query("permidgetbyname")
     assert q._parameter_blocks == []
 
-    q.param_block(permsid="b_serverinstance_help_view")
-    q.param_block(permsid="b_serverinstance_info_view")
+    q = q.param_block(permsid="b_serverinstance_help_view")
+    q = q.param_block(permsid="b_serverinstance_info_view")
 
     assert {"permsid": "b_serverinstance_help_view"} in q._parameter_blocks
     assert {"permsid": "b_serverinstance_info_view"} in q._parameter_blocks
+
+
+def test_add_param_blocks_list():
+    q = query("permidgetbyname")
+    assert q._parameter_blocks == []
+
+    q = q.param_block(
+        [
+            {"permsid": "b_serverinstance_help_view"},
+            {"permsid": "b_serverinstance_info_view"},
+        ],
+    )
+
+    q = q.param_block(
+        ({"permsid": perm})
+        for perm in ("b_serverinstance_permission_list", "b_serverinstance_binding_list")
+    )
+
+    assert {"permsid": "b_serverinstance_help_view"} in q._parameter_blocks
+    assert {"permsid": "b_serverinstance_info_view"} in q._parameter_blocks
+    assert {"permsid": "b_serverinstance_permission_list"} in q._parameter_blocks
+    assert {"permsid": "b_serverinstance_binding_list"} in q._parameter_blocks
 
 
 @pytest.mark.parametrize(
@@ -65,7 +88,10 @@ def test_app_param_blocks():
             id="test_param_block_multiple",
         ),
         pytest.param(
-            query("ftdeletefile").params(cid=2, cpw="").param_block(name="/Pic1.PNG").param_block(name="/Pic2.PNG"),
+            query("ftdeletefile")
+            .params(cid=2, cpw="")
+            .param_block(name="/Pic1.PNG")
+            .param_block(name="/Pic2.PNG"),
             r"ftdeletefile cid=2 cpw= name=\/Pic1.PNG|name=\/Pic2.PNG",
             id="test_empty_param",
         ),
@@ -86,36 +112,19 @@ def test_caching():
 
     first_compile = q.compile()
 
-    assert q._dirty == False
     assert q._cached_command
-
     assert first_compile == q.compile()
 
 
 def test_cache_invalid(q: TSQuery):
     first_compile = q.compile()
 
-    q.option("continueonerror")
+    q = q.option("continueonerror")
 
-    assert q._dirty == True
+    assert not q._cached_command
     assert first_compile != q.compile()
 
 
 @pytest.fixture
 def q():
     return query("channelmove").params(cid=16, cpid=1, order=0)
-
-
-@pytest.mark.parametrize(
-    ("method", "args", "kwargs"),
-    (
-        pytest.param("option", ("continueonerror",), {}, id="test_option"),
-        pytest.param("params", (), {"cldbid": 16}, id="test_option"),
-        pytest.param("param_block", (), {"cldbid": 16}, id="test_option"),
-    ),
-)
-def test_sets_dirty_bit(q: TSQuery, method: str, args: tuple[str, ...], kwargs: dict[str, str]):
-    q._dirty = False
-    getattr(q, method)(*args, **kwargs)
-
-    assert q._dirty == True

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -9,10 +9,10 @@ from tsbot.query_builder import TSQuery, query
 
 def test_add_options():
     q = query("channellist")
-    assert q._options == []
+    assert len(q._options) == 0
 
     q = q.option("topic", "flags", "voice")
-    assert q._options == ["topic", "flags", "voice"]
+    assert q._options == ("topic", "flags", "voice")
 
 
 def test_add_params():
@@ -25,7 +25,7 @@ def test_add_params():
 
 def test_add_param_blocks():
     q = query("permidgetbyname")
-    assert q._parameter_blocks == []
+    assert len(q._parameter_blocks) == 0
 
     q = q.param_block(permsid="b_serverinstance_help_view")
     q = q.param_block(permsid="b_serverinstance_info_view")
@@ -36,7 +36,7 @@ def test_add_param_blocks():
 
 def test_add_param_blocks_list():
     q = query("permidgetbyname")
-    assert q._parameter_blocks == []
+    assert len(q._parameter_blocks) == 0
 
     q = q.param_block(
         [

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -193,7 +193,6 @@ class TSBot:
         *,
         name: str | None = None,
     ) -> tasks.TSTask:
-
         task = tasks.TSTask(handler=tasks.every(handler, seconds), name=name)
         self.tasks_handler.register_task(self, task)
         return task
@@ -455,7 +454,6 @@ class TSBot:
 
         for plugin_to_be_loaded in plugins:
             for _, member in inspect.getmembers(plugin_to_be_loaded):
-
                 if command_kwargs := getattr(member, "__ts_command__", None):
                     self.register_command(handler=member, **command_kwargs)
 

--- a/tsbot/commands/handler.py
+++ b/tsbot/commands/handler.py
@@ -62,7 +62,7 @@ class CommandHandler:
             return
 
         # Create new context dict with useful entries
-        ctx = context.TSCtx({"command": command, "raw_args": args} | event.ctx)
+        ctx = context.TSCtx({"command": command, "raw_args": args, **event.ctx})
 
         logger.debug("%r executed command %r -> %r", event.ctx["invokername"], command, args)
 
@@ -71,7 +71,7 @@ class CommandHandler:
 
         except exceptions.TSException as e:
             if error_event := _ERROR_EVENT_MAP.get(type(e)):
-                bot.emit(event_name=error_event, ctx={"exception": e} | ctx)
+                bot.emit(event_name=error_event, ctx={"exception": e, **event.ctx})
                 return
 
             raise

--- a/tsbot/query_builder.py
+++ b/tsbot/query_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TypeVar
+import copy
+from typing import Iterable, TypeVar
 
 from tsbot import utils
 
@@ -17,70 +18,97 @@ class TSQuery:
     __slots__ = (
         "command",
         "_cached_command",
-        "_dirty",
         "_options",
         "_parameters",
         "_parameter_blocks",
     )
 
-    def __init__(self, command: str) -> None:
+    def __init__(
+        self,
+        command: str,
+        options: list[str] | None = None,
+        parameters: dict[str, str] | None = None,
+        parameter_blocks: list[dict[str, str]] | None = None,
+    ) -> None:
         if not command:
             raise ValueError("Command cannot be empty")
 
         self.command = command
 
         self._cached_command: str = ""
-        self._dirty = True
 
-        self._options: list[str] = []
-        self._parameters: dict[str, str] = {}
-        self._parameter_blocks: list[dict[str, str]] = []
+        self._options = options or []
+        self._parameters = parameters or {}
+        self._parameter_blocks = parameter_blocks or []
 
     def __repr__(self) -> str:
         return f"{self.__class__.__qualname__}({self.command!r})"
 
     def option(self: _T, *args: ParameterTypes) -> _T:
         """Add options to the command eg. ``-groups``"""
-        self._dirty = True
 
-        self._options.extend(map(str, args))
-        return self
+        return type(self)(
+            self.command,
+            [*self._options, *map(str, args)],
+            copy.copy(self._parameters),
+            copy.deepcopy(self._parameter_blocks),
+        )
 
     def params(self: _T, **kwargs: ParameterTypes) -> _T:
         """Add parameters to the command eg. ``cldbid=12``"""
-        self._dirty = True
 
-        self._parameters.update({k: str(v) for k, v in kwargs.items()})
-        return self
+        return type(self)(
+            self.command,
+            copy.copy(self._options),
+            {**self._parameters, **{k: str(v) for k, v in kwargs.items()}},
+            copy.deepcopy(self._parameter_blocks),
+        )
 
-    def param_block(self: _T, **kwargs: ParameterTypes) -> _T:
+    def param_block(
+        self: _T,
+        block: Iterable[dict[str, ParameterTypes]] | None = None,
+        /,
+        **kwargs: ParameterTypes,
+    ) -> _T:
         """Add parameter blocks eg. ``clid=1 | clid=2 | clid=3`` to the command"""
-        self._dirty = True
 
-        self._parameter_blocks.append({k: str(v) for k, v in kwargs.items()})
-        return self
+        param_blocks = tuple(block) if block else (kwargs,)
+
+        return type(self)(
+            self.command,
+            copy.copy(self._options),
+            copy.copy(self._parameters),
+            [
+                *self._parameter_blocks,
+                *({k: str(v) for k, v in block.items()} for block in param_blocks),
+            ],
+        )
 
     def compile(self) -> str:
         """Compiles the query into a raw command"""
 
-        if not self._dirty:
+        if self._cached_command:
             return self._cached_command
 
         compiled = self.command
 
         if self._parameters:
-            compiled += f" {' '.join(f'{k}={utils.escape(v)}' for k, v in self._parameters.items())}"
+            compiled += (
+                f" {' '.join(f'{k}={utils.escape(v)}' for k, v in self._parameters.items())}"
+            )
 
         if self._parameter_blocks:
             compiled_blocks: list[str] = []
 
             for parameters in self._parameter_blocks:
-                compiled_blocks.append(" ".join(f"{k}={utils.escape(v)}" for k, v in parameters.items()))
+                compiled_blocks.append(
+                    " ".join(f"{k}={utils.escape(v)}" for k, v in parameters.items())
+                )
 
             compiled += f" {'|'.join(compiled_blocks)}"
 
         if self._options:
             compiled += f" {' '.join(f'-{option}' for option in self._options)}"
 
-        self._cached_command, self._dirty = compiled, False
+        self._cached_command = compiled
         return compiled


### PR DESCRIPTION
Make TSQuery objects immutable.

This makes queries stable and allows changing parameters and options easier.
Example:
```python
@bot.command("immutable", "Test immutability")
async def immutability(bot: TSBot, ctx: context.TSCtx, message: str) -> None:
    q = query("sendtextmessage")
    server_wide = q.params(msg=f"SERVER WIDE: {message}", targetmode=3)
    channel_wide = q.params(msg=f"Channel wide: {message}", targetmode=2)

    await asyncio.wait([bot.send(server_wide), bot.send(channel_wide)])
```

This is a breaking change since you need to assing/reassign TSQuery method calls to a variable.