### PR TITLE
Remove tasks decorators

### DIFF
--- a/docs/source/tasks.md
+++ b/docs/source/tasks.md
@@ -26,7 +26,7 @@ bot.register_task(functools.partial(example_task, arg1=1, arg2="test"))
 ```{warning}
 Tasks handling is started before the bot is connected to the server.
 If you need the bot to be connected to the TeamSpeak server, Use build-in
-`ready` [event](./events.md#built-in-events).
+`ready` [event](./events.md#built-in-events) event handlers to register tasks.
 ```
 
 ## Every task

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -11,7 +11,6 @@ from typing import (
     Concatenate,
     Coroutine,
     ParamSpec,
-    overload,
 )
 
 from tsbot import (
@@ -237,25 +236,9 @@ class TSBot:
         """
         self.command_handler.remove_command(command)
 
-    def every(
-        self, seconds: int, name: str | None = None
-    ) -> Callable[[tasks.TTaskH], tasks.TTaskH]:
-        """
-        Decorator to register tasks to be ran every given second.
-
-        :param seconds: How often the task is executed.
-        :param name: Name of the task.
-        """
-
-        def every_decorator(func: tasks.TTaskH) -> tasks.TTaskH:
-            self.register_every_task(seconds, func, name=name)
-            return func
-
-        return every_decorator
-
     def register_every_task(
         self,
-        seconds: int,
+        seconds: float,
         handler: tasks.TTaskH,
         *,
         name: str | None = None,
@@ -271,31 +254,6 @@ class TSBot:
         task = tasks.TSTask(handler=tasks.every(handler, seconds), name=name)
         self.tasks_handler.register_task(self, task)
         return task
-
-    @overload
-    def task(self, *, name: str | None) -> Callable[[tasks.TTaskH], tasks.TTaskH]: ...
-
-    @overload
-    def task(self, func: tasks.TTaskH) -> tasks.TTaskH: ...
-
-    def task(
-        self, func: tasks.TTaskH | None = None, *, name: str | None = None
-    ) -> tasks.TTaskH | Callable[[tasks.TTaskH], tasks.TTaskH]:
-        """
-        Decorator to register a background tasks.
-
-        :param func: Async function to handle task.
-        :param name: Name of the task.
-        """
-
-        def task_decorator(func: tasks.TTaskH) -> tasks.TTaskH:
-            self.register_task(func, name=name)
-            return func
-
-        if func is None:
-            return task_decorator
-
-        return task_decorator(func)
 
     def register_task(
         self,
@@ -522,12 +480,6 @@ class TSBot:
 
                 elif once_kwargs := getattr(member, "__ts_once__", None):
                     self.register_once_handler(handler=member, **once_kwargs)
-
-                elif every_kwargs := getattr(member, "__ts_every__", None):
-                    self.register_every_task(handler=member, **every_kwargs)
-
-                elif task_kwargs := getattr(member, "__ts_task__", None):
-                    self.register_task(handler=member, **task_kwargs)
 
             self.plugins[plugin_to_be_loaded.__class__.__name__] = plugin_to_be_loaded
 

--- a/tsbot/default_plugins/keepalive.py
+++ b/tsbot/default_plugins/keepalive.py
@@ -20,7 +20,10 @@ class KeepAlive(plugin.TSPlugin):
     def __init__(self) -> None:
         self.command_sent_event = asyncio.Event()
 
-    @plugin.task(name="KeepAlive-Task")
+    @plugin.once("ready")
+    async def init_keep_alive(self, bot: bot.TSBot, ctx: None) -> None:
+        bot.register_task(self._keep_alive_task, name="KeepAlive-Task")
+
     async def _keep_alive_task(self, bot: bot.TSBot) -> None:
         """
         Task to keep connection alive with the TeamSpeak server

--- a/tsbot/plugin.py
+++ b/tsbot/plugin.py
@@ -8,7 +8,6 @@ from typing import (
     Coroutine,
     ParamSpec,
     TypeVar,
-    overload,
 )
 
 if TYPE_CHECKING:
@@ -81,56 +80,3 @@ def once(
         return func
 
     return once_decorator
-
-
-@overload
-def task(*, name: str | None) -> Callable[
-    [Callable[[_T, bot.TSBot], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot], Coroutine[None, None, None]],
-]: ...
-
-
-@overload
-def task(
-    func: Callable[[_T, bot.TSBot], Coroutine[None, None, None]],
-) -> Callable[[_T, bot.TSBot], Coroutine[None, None, None]]: ...
-
-
-def task(
-    func: Callable[[_T, bot.TSBot], Coroutine[None, None, None]] | None = None,
-    *,
-    name: str | None = None,
-) -> (
-    Callable[[_T, bot.TSBot], Coroutine[None, None, None]]
-    | Callable[
-        [Callable[[_T, bot.TSBot], Coroutine[None, None, None]]],
-        Callable[[_T, bot.TSBot], Coroutine[None, None, None]],
-    ]
-):
-    """Decorator to register plugin tasks"""
-
-    def task_decorator(
-        func: Callable[[_T, bot.TSBot], Coroutine[None, None, None]]
-    ) -> Callable[[_T, bot.TSBot], Coroutine[None, None, None]]:
-        func.__ts_task__ = {"name": name}  # type: ignore
-        return func
-
-    if func is not None:
-        return task_decorator(func)
-
-    return task_decorator
-
-
-def every(seconds: int, name: str | None = None) -> Callable[
-    [Callable[[_T, bot.TSBot], Coroutine[None, None, None]]],
-    Callable[[_T, bot.TSBot], Coroutine[None, None, None]],
-]:
-    """Decorator to register plugin every tasks"""
-
-    def every_decorator(
-        func: Callable[[_T, bot.TSBot], Coroutine[None, None, None]]
-    ) -> Callable[[_T, bot.TSBot], Coroutine[None, None, None]]:
-        func.__ts_every__ = {"seconds": seconds, "name": name}  # type: ignore
-        return func
-
-    return every_decorator

--- a/tsbot/tasks/tstask.py
+++ b/tsbot/tasks/tstask.py
@@ -19,7 +19,7 @@ class TSTask:
     task: asyncio.Task[None] | None = None
 
 
-def every(every_handler: TTaskH, seconds: int) -> TTaskH:
+def every(every_handler: TTaskH, seconds: float) -> TTaskH:
     @functools.wraps(every_handler)
     async def every_wrapper(bot: bot.TSBot) -> None:
         while True:


### PR DESCRIPTION
Since tasks handling is started before the bot is connected, these decorators can cause confusion.
To register tasks on connection, use `on("ready)` event handlers to register the task.
