### PR TITLE
Stringify during compilation

### DIFF
--- a/docs/source/queries.md
+++ b/docs/source/queries.md
@@ -80,7 +80,13 @@ The method [params()](<tsbot.query_builder.TSQuery.params()>) accepts parameters
 You can supply as **_many arguments_** as want or add them **_one by one_**.
 
 Values can be anything that implements `__str__()` method.
-The method [params()](<tsbot.query_builder.TSQuery.params()>) calls [str()](str) on each value that is added.
+During query compilation, `str()` will be called on the value.  
+Values `True` or `False` will be converted to `'1'` and `'0'` respectively during compilation.
+
+```python
+# `force=True` will be converted to `force=1` during compilation
+example_query = query("channeldelete").params(cid=1, force=True)
+```
 
 Since [params()](<tsbot.query_builder.TSQuery.params()>) accepts **_keys_** and **_values_**,
 this allows us to build the parameters as a [dict](dict) and spread the dictionary when calling the method.
@@ -102,6 +108,8 @@ example_query = example_query.params(msg="Wake up!")
 params = {"clid": 1, "msg": "Wake up!"}
 example_query = example_query.params(**params)
 ```
+
+
 
 ### Adding parameter blocks
 

--- a/examples/file_transfer.py
+++ b/examples/file_transfer.py
@@ -62,7 +62,7 @@ async def upload(
         cid=cid,
         cpw=cpw,
         resume=0,
-        overwrite=1 if overwrite else 0,
+        overwrite=overwrite,
     )
 
     resp = await bot.send(init_query)

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -20,7 +20,7 @@ def test_add_params():
     assert q._parameters == {}
 
     q = q.params(cid=16, cpid=1, order=0)
-    assert q._parameters == {"cid": "16", "cpid": "1", "order": "0"}
+    assert q._parameters == {"cid": 16, "cpid": 1, "order": 0}
 
 
 def test_add_param_blocks():
@@ -113,10 +113,11 @@ def test_caching():
     first_compile = q.compile()
 
     assert q._cached_command
-    assert first_compile == q.compile()
+    assert first_compile is q.compile()
 
 
-def test_cache_invalid(q: TSQuery):
+def test_cache_invalid():
+    q = query("channelmove").params(cid=16, cpid=1, order=0)
     first_compile = q.compile()
 
     q = q.option("continueonerror")
@@ -125,6 +126,20 @@ def test_cache_invalid(q: TSQuery):
     assert first_compile != q.compile()
 
 
-@pytest.fixture
-def q():
-    return query("channelmove").params(cid=16, cpid=1, order=0)
+@pytest.mark.parametrize(
+    ("q", "includes"),
+    (
+        pytest.param(
+            query("channeldelete").params(cid=1, force=True),
+            "force=1",
+            id="test_boolean_conversion_true",
+        ),
+        pytest.param(
+            query("channeldelete").params(cid=1, force=False),
+            "force=0",
+            id="test_boolean_conversion_false",
+        ),
+    ),
+)
+def test_boolean_params(q: TSQuery, includes: str):
+    assert includes in q.compile()

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -420,7 +420,7 @@ class TSBot:
 
         async def select_server() -> None:
             """Set current virtual server"""
-            await self.send(query_builder.TSQuery("use", parameters={"sid": str(self.server_id)}))
+            await self.send(query_builder.TSQuery("use", parameters={"sid": self.server_id}))
 
         async def register_notifies() -> None:
             """Coroutine to register server to send events to the bot"""
@@ -496,7 +496,7 @@ class TSBot:
         await self.send(
             query_builder.TSQuery(
                 "sendtextmessage",
-                parameters={"targetmode": target_mode.value, "target": target, "msg": str(message)},
+                parameters={"targetmode": target_mode.value, "target": target, "msg": message},
             )
         )
 
@@ -515,7 +515,7 @@ class TSBot:
                     parameters={
                         "targetmode": enums.TextMessageTargetMode.CLIENT.value,
                         "target": target,
-                        "msg": str(message),
+                        "msg": message,
                     },
                 )
             )

--- a/tsbot/query_builder.py
+++ b/tsbot/query_builder.py
@@ -22,8 +22,8 @@ def query(command: str) -> TSQuery:
     return TSQuery(command)
 
 
-def _to_dict_values(kv: tuple[str, Stringable]) -> tuple[str, str]:
-    return kv[0], str(kv[1])
+def _format_value(key: str, value: Stringable) -> str:
+    return f"{key}={int(value) if isinstance(value, bool) else utils.escape(str(value))}"
 
 
 def _format_value(kv: tuple[str, str]) -> str:


### PR DESCRIPTION
## feat: Booleans are interpret as int
Booleans can now be passed as values to param methods.
```python
query("channeldelete").params(cid=10, force=True)
```

## fix: Stringify only during compilation
Before the values were stringified during the method call. 
This can cause problems when creating TSQuery objects without calling such methods.

Moving stringifying to the compile step, values are guaranteed to be in the right format, when the query is sent.