### PR TITLE
fix: only strip on right

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -240,7 +240,7 @@ def test_internal_read(connected_conn: connection.TSConnection):
     line = asyncio.run(connected_conn._read())
 
     assert isinstance(line, str)
-    assert line == "line 1\n\r"
+    assert line == "line 1"
 
 
 def test_internal_read_exception_incomplete(


### PR DESCRIPTION
Fixes an issue where a response would include error line as an example.
(Mainly when using `help <command>` query) 
Reader would see more error lines than expected and crash due to invalid state. 
