### PR TITLE
refactor: Improve internals

### DIFF
--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -8,19 +8,19 @@ from tsbot import parsers
 @pytest.mark.parametrize(
     ("input_str", "expected"),
     (
-        pytest.param("", [], id="test_empty"),
-        pytest.param("ip=0.0.0.0|ip=::", [{"ip": "0.0.0.0"}, {"ip": "::"}], id="test_simple"),
+        pytest.param("", tuple(), id="test_empty"),
+        pytest.param("ip=0.0.0.0|ip=::", ({"ip": "0.0.0.0"}, {"ip": "::"}), id="test_simple"),
         pytest.param(
             "clid=14 client_nickname=Sven|clid=17 client_nickname=SvenBot",
-            [
+            (
                 {"clid": "14", "client_nickname": "Sven"},
                 {"clid": "17", "client_nickname": "SvenBot"},
-            ],
+            ),
             id="test_multiple_data_simple",
         ),
         pytest.param(
             "cgid=1 name=Channel\\sAdmin type=0 iconid=100 savedb=1 sortid=0 namemode=0 n_modifyp=75 n_member_addp=50 n_member_removep=50|cgid=2 name=Operator type=0 iconid=200 savedb=1 sortid=0 namemode=0 n_modifyp=75 n_member_addp=30 n_member_removep=30|cgid=3 name=Voice type=0 iconid=600 savedb=1 sortid=0 namemode=0 n_modifyp=75 n_member_addp=25 n_member_removep=25|cgid=4 name=Guest type=0 iconid=0 savedb=0 sortid=0 namemode=0 n_modifyp=75 n_member_addp=0 n_member_removep=0|cgid=5 name=Channel\\sAdmin type=1 iconid=100 savedb=1 sortid=0 namemode=0 n_modifyp=75 n_member_addp=50 n_member_removep=50|cgid=6 name=Operator type=1 iconid=200 savedb=1 sortid=0 namemode=0 n_modifyp=75 n_member_addp=30 n_member_removep=30|cgid=7 name=Voice type=1 iconid=600 savedb=1 sortid=0 namemode=0 n_modifyp=75 n_member_addp=25 n_member_removep=25|cgid=8 name=Guest type=1 iconid=0 savedb=0 sortid=0 namemode=0 n_modifyp=75 n_member_addp=0 n_member_removep=0",
-            [
+            (
                 {
                     "cgid": "1",
                     "name": "Channel Admin",
@@ -117,7 +117,7 @@ from tsbot import parsers
                     "n_member_addp": "0",
                     "n_member_removep": "0",
                 },
-            ],
+            ),
             id="test_multiple_data_complex",
         ),
     ),
@@ -175,7 +175,7 @@ def test_parse_line(input_str: str, expected: dict[str, str]) -> None:
             ("client_servergroups", "6,16,20"),
             id="test_comma_sepparated",
         ),
-        pytest.param("clid=11|clid=12|clid=13", ("clid", "11,12,13"), id="test_param_block"),
+        pytest.param("clid=11|clid=12|clid=13", ("clid", "11,12,13"), id="test_multiple_values"),
         pytest.param(
             "channel_name=Bot\\sCommands",
             ("channel_name", "Bot Commands"),

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -11,13 +11,13 @@ from tsbot import response
     (
         pytest.param(
             ["error id=0 msg=ok"],
-            {"data": [], "error_id": 0, "msg": "ok"},
+            {"data": tuple(), "error_id": 0, "msg": "ok"},
             id="test_acknowledgement",
         ),
         pytest.param(
             ["version=3.13.3 build=1608128225 platform=Windows", "error id=0 msg=ok"],
             {
-                "data": [{"version": "3.13.3", "build": "1608128225", "platform": "Windows"}],
+                "data": ({"version": "3.13.3", "build": "1608128225", "platform": "Windows"},),
                 "error_id": 0,
                 "msg": "ok",
             },
@@ -25,12 +25,12 @@ from tsbot import response
         ),
         pytest.param(
             ["error id=256 msg=command\\snot\\sfound"],
-            {"data": [], "error_id": 256, "msg": "command not found"},
+            {"data": tuple(), "error_id": 256, "msg": "command not found"},
             id="test_error",
         ),
         pytest.param(
             ["ip=0.0.0.0|ip=::", "error id=0 msg=ok"],
-            {"data": [{"ip": "0.0.0.0"}, {"ip": "::"}], "error_id": 0, "msg": "ok"},
+            {"data": ({"ip": "0.0.0.0"}, {"ip": "::"}), "error_id": 0, "msg": "ok"},
             id="test_multiple_results",
         ),
     ),
@@ -44,16 +44,16 @@ def test_from_server_response(input_list: list[str], expected_values: dict[str, 
 
 def test_first_property():
     resp = response.TSResponse(
-        [{"version": "3.13.3", "build": "1608128225", "platform": "Windows"}], 0, "ok"
+        ({"version": "3.13.3", "build": "1608128225", "platform": "Windows"},), 0, "ok"
     )
     assert resp.first == {"version": "3.13.3", "build": "1608128225", "platform": "Windows"}
 
-    resp = response.TSResponse([{"ip": "0.0.0.0"}, {"ip": "::"}], 0, "ok")
+    resp = response.TSResponse(({"ip": "0.0.0.0"}, {"ip": "::"}), 0, "ok")
     assert resp.first == {"ip": "0.0.0.0"}
 
 
 def test_first_property_empty():
-    resp = response.TSResponse([], 0, "ok")
+    resp = response.TSResponse(tuple(), 0, "ok")
 
     with pytest.raises(IndexError):
         resp.first
@@ -61,14 +61,14 @@ def test_first_property_empty():
 
 def test_iter_response():
     resp = response.TSResponse(
-        data=[
+        data=(
             {"clid": "378", "cid": "23", "client_database_id": "21", "client_type": "0"},
             {"clid": "377", "cid": "31", "client_database_id": "549", "client_type": "0"},
             {"clid": "375", "cid": "31", "client_database_id": "46", "client_type": "0"},
             {"clid": "371", "cid": "31", "client_database_id": "385", "client_type": "0"},
             {"clid": "333", "cid": "45", "client_database_id": "27", "client_type": "0"},
             {"clid": "3", "cid": "31", "client_database_id": "160", "client_type": "0"},
-        ],
+        ),
         error_id=0,
         msg="ok",
     )
@@ -78,5 +78,5 @@ def test_iter_response():
 
 
 def test_response_repr():
-    resp = response.TSResponse([{"ip": "0.0.0.0"}, {"ip": "::"}], 0, "ok")
+    resp = response.TSResponse(({"ip": "0.0.0.0"}, {"ip": "::"}), 0, "ok")
     assert repr(resp)

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -371,20 +371,20 @@ class TSBot:
         cancels background tasks and send quit command.
         """
 
-        async def _close() -> None:
-            logger.info("Closing")
-            self.emit(event_name="close")
-            await self._tasks_handler.close()
-            await self._event_handler.run_till_empty(self)
-
-            with contextlib.suppress(Exception):
-                await self.send_raw("quit")
-
-            logger.info("Closing done")
-
         if not self._closing:
             self._closing = True
-            asyncio.create_task(_close())
+            asyncio.create_task(self._close())
+
+    async def _close(self) -> None:
+        logger.info("Closing bot")
+        self.emit(event_name="close")
+        await self._tasks_handler.close()
+        await self._event_handler.run_till_empty(self)
+
+        with contextlib.suppress(Exception):
+            await self.send_raw("quit")
+
+        logger.info("Closing done")
 
     async def run(self) -> None:
         """
@@ -445,7 +445,7 @@ class TSBot:
             await reader_task
 
         finally:
-            await self.close()
+            await self._close()
             await self._connection.close()
 
     def load_plugin(self, *plugins: plugin.TSPlugin) -> None:

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -115,7 +115,7 @@ class TSBot:
         self, event_type: str, handler: events.TEventHandler
     ) -> events.TSEventHandler:
         """
-        Register an event handler to be ran on an event
+        Register an event handler to be ran on an event.
 
         :param event_type: Name of the event.
         :param handler: async function to handle the event.
@@ -277,7 +277,7 @@ class TSBot:
 
     async def send(self, query: query_builder.TSQuery) -> response.TSResponse:
         """
-        Sends queries to the server, assuring only one of them gets sent at a time
+        Sends queries to the server, assuring only one of them gets sent at a time.
 
         :param query: Instance of :class:`TSQuery<tsbot.query_builder.TSQuery>` to be send to the server.
         :return: Response from the server.
@@ -330,16 +330,16 @@ class TSBot:
 
         if server_response.error_id != 0:
             raise exceptions.TSResponseError(
-                msg=server_response.msg, error_id=int(server_response.error_id)
+                msg=server_response.msg,
+                error_id=int(server_response.error_id),
             )
 
         return server_response
 
     async def _reader_task(self, ready_event: asyncio.Event) -> None:
-        """Task to read messages from the server"""
+        """Task to read messages from the server."""
 
         WELCOME_MESSAGE_LENGTH = 2
-
         async for data in self._connection.read_lines(WELCOME_MESSAGE_LENGTH):
             pass
 
@@ -365,7 +365,7 @@ class TSBot:
 
     async def close(self) -> None:
         """
-        Async function to handle closing the bot
+        Async method to handle closing the bot.
 
         Emits `close` event to notify client closing,
         cancels background tasks and send quit command.

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -371,7 +371,7 @@ class TSBot:
         cancels background tasks and send quit command.
         """
 
-        async def close():
+        async def _close() -> None:
             logger.info("Closing")
             self.emit(event_name="close")
             await self._tasks_handler.close()
@@ -384,7 +384,7 @@ class TSBot:
 
         if not self._closing:
             self._closing = True
-            asyncio.create_task(close())
+            asyncio.create_task(_close())
 
     async def run(self) -> None:
         """

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -230,6 +230,15 @@ class TSBot:
         """
         self._command_handler.remove_command(command)
 
+    def get_command_handler(self, command: str):
+        """
+        Get :class:`TSCommand<tsbot.commands.TSCommand>` instance associated with a given `str`
+
+        :param command: command that invokes :class:`TSCommand<tsbot.commands.TSCommand>`
+        :return: :class:`TSCommand<tsbot.commands.TSCommand>` associated with `command`
+        """
+        return self._command_handler.commands.get(command)
+
     def register_every_task(
         self,
         seconds: float,

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -363,11 +363,11 @@ class TSBot:
 
         logger.debug("Reader task done")
 
-    async def close(self) -> None:
+    def close(self) -> None:
         """
-        Async method to handle closing the bot.
+        Method to close the bot.
 
-        Emits `close` event to notify client closing,
+        Emits `close` event to notify that the client is closing,
         cancels background tasks and send quit command.
         """
 

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -18,6 +18,7 @@ from tsbot import (
     ratelimiter,
     response,
     tasks,
+    utils,
 )
 
 if TYPE_CHECKING:
@@ -284,10 +285,7 @@ class TSBot:
         try:
             return await self.send_raw(query.compile())
         except exceptions.TSResponseError as response_error:
-            if (tb := response_error.__traceback__) and tb.tb_next:
-                response_error = response_error.with_traceback(tb.tb_next.tb_next)
-
-            raise response_error
+            raise utils.pop_traceback(response_error, 2)
 
     async def send_raw(self, raw_query: str) -> response.TSResponse:
         """
@@ -302,10 +300,7 @@ class TSBot:
         try:
             return await asyncio.shield(self._send(raw_query))
         except exceptions.TSResponseError as response_error:
-            if (tb := response_error.__traceback__) and tb.tb_next:
-                response_error = response_error.with_traceback(tb.tb_next.tb_next)
-
-            raise response_error
+            raise utils.pop_traceback(response_error, 2)
 
     async def _send(self, raw_query: str) -> response.TSResponse:
         """Method responsibe for actually sending the data."""

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -69,7 +69,7 @@ class TSBot:
         self._event_handler = events.EventHandler()
         self._command_handler = commands.CommandHandler(invoker)
 
-        self.ratelimited = ratelimited
+        self._ratelimited = ratelimited
         self._ratelimiter = ratelimiter.RateLimiter(
             max_calls=ratelimit_calls, period=ratelimit_period
         )
@@ -308,7 +308,7 @@ class TSBot:
         async with self._sending_lock:
             self._response = asyncio.Future()
 
-            if self.ratelimited:
+            if self._ratelimited:
                 await self._ratelimiter.wait()
 
             logger.debug("Sending query: %r", raw_query)

--- a/tsbot/bot.py
+++ b/tsbot/bot.py
@@ -230,7 +230,7 @@ class TSBot:
         """
         self._command_handler.remove_command(command)
 
-    def get_command_handler(self, command: str):
+    def get_command_handler(self, command: str) -> commands.TSCommand | None:
         """
         Get :class:`TSCommand<tsbot.commands.TSCommand>` instance associated with a given `str`
 

--- a/tsbot/commands/handler.py
+++ b/tsbot/commands/handler.py
@@ -28,9 +28,9 @@ class CommandHandler:
         self.commands.update({c: command for c in command.commands})
 
         logger.debug(
-            "Registered %s command to execute %r",
+            "Registered %s command to execute handler %r",
             ", ".join(repr(c) for c in command.commands),
-            command.handler,
+            command.handler.__name__,
         )
 
     def remove_command(self, command: commands.TSCommand) -> None:

--- a/tsbot/connection.py
+++ b/tsbot/connection.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import AsyncGenerator
 
@@ -62,7 +61,7 @@ class TSConnection:
 
         try:
             data = await self._reader.readuntil("\n\r")
-        except (asyncio.IncompleteReadError, ConnectionResetError):
+        except Exception:
             return None
         else:
             return data.rstrip()

--- a/tsbot/connection.py
+++ b/tsbot/connection.py
@@ -62,7 +62,7 @@ class TSConnection:
 
         try:
             data = await self._reader.readuntil("\n\r")
-        except asyncio.IncompleteReadError:
+        except (asyncio.IncompleteReadError, ConnectionResetError):
             return None
         else:
             return data.rstrip()

--- a/tsbot/default_plugins/help.py
+++ b/tsbot/default_plugins/help.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class Help(plugin.TSPlugin):
     @plugin.command("help", help_text="Prints out the help text of a given command and usage")
     async def help_command(self, bot: bot.TSBot, ctx: context.TSCtx, command: str) -> None:
-        command_handler = bot._command_handler.commands.get(command)  # type: ignore
+        command_handler = bot.get_command_handler(command)
 
         if not command_handler or command_handler.hidden:
             raise exceptions.TSCommandError("Command not found")

--- a/tsbot/default_plugins/help.py
+++ b/tsbot/default_plugins/help.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class Help(plugin.TSPlugin):
     @plugin.command("help", help_text="Prints out the help text of a given command and usage")
     async def help_command(self, bot: bot.TSBot, ctx: context.TSCtx, command: str) -> None:
-        command_handler = bot.command_handler.commands.get(command)
+        command_handler = bot._command_handler.commands.get(command)  # type: ignore
 
         if not command_handler or command_handler.hidden:
             raise exceptions.TSCommandError("Command not found")

--- a/tsbot/events/handler.py
+++ b/tsbot/events/handler.py
@@ -5,6 +5,8 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+from tsbot import utils
+
 if TYPE_CHECKING:
     from tsbot import bot, events
 
@@ -14,53 +16,57 @@ logger = logging.getLogger(__name__)
 
 class EventHandler:
     def __init__(self) -> None:
-        self.event_handlers: defaultdict[str, list[events.TSEventHandler]] = defaultdict(list)
-        self.event_queue: asyncio.Queue[events.TSEvent] = asyncio.Queue()
+        self._event_handlers: defaultdict[str, list[events.TSEventHandler]] = defaultdict(list)
+        self._event_queue: asyncio.Queue[events.TSEvent] = asyncio.Queue()
+        self._closed = False
+
+    def add_event(self, event: events.TSEvent) -> None:
+        if self._closed:
+            logger.warn("Event %r emitted during closing and is ignored", event.event)
+        else:
+            self._event_queue.put_nowait(event)
 
     def handle_event(self, bot: bot.TSBot, event: events.TSEvent) -> None:
-        logger.debug("Got event: %s", event)
-
-        handlers = self.event_handlers.get(event.event)
+        logger.debug("Got event: %r", event)
+        handlers = self._event_handlers.get(event.event)
 
         if not handlers:
-            self.event_queue.task_done()
+            self._event_queue.task_done()
             return
 
         tasks = [asyncio.create_task(h.run(bot, event), name="EventHandler") for h in handlers]
+        watcher = asyncio.create_task(asyncio.wait(tasks), name="EventWatcher")
+        watcher.add_done_callback(lambda _: self._event_queue.task_done())
 
-        task = asyncio.create_task(asyncio.wait(tasks), name="EventWatcher")
-        task.add_done_callback(lambda _: self.event_queue.task_done())
+    async def run_till_empty(self, bot: bot.TSBot) -> None:
+        while not self._event_queue.empty():
+            self.handle_event(bot, self._event_queue.get_nowait())
 
-    def run_till_empty(self, bot: bot.TSBot) -> None:
-        while not self.event_queue.empty():
-            self.handle_event(bot, self.event_queue.get_nowait())
+        await self._event_queue.join()
 
     async def handle_events_task(self, bot: bot.TSBot) -> None:
-        """
-        Task to run events put into the self.event_queue
+        """Task to run events put into the event queue."""
 
-        if task is cancelled, it will try to run all the events
-        still in the queue until empty
-        """
+        with utils.toggle(self, "_closed", enter=False, exit=True):
+            try:
+                while True:
+                    self.handle_event(bot, await self._event_queue.get())
 
-        try:
-            while True:
-                self.handle_event(bot, await self.event_queue.get())
-
-        except asyncio.CancelledError:
-            logger.debug("Cancelling event handling")
-            self.run_till_empty(bot)
+            except asyncio.CancelledError:
+                logger.debug("Cancelling event handling")
 
     def register_event_handler(self, event_handler: events.TSEventHandler) -> None:
-        """Registers event handlers that will be called when given event happens"""
-        self.event_handlers[event_handler.event].append(event_handler)
+        """Registers event handlers that will be called when given event happens."""
+        self._event_handlers[event_handler.event].append(event_handler)
 
         logger.debug(
-            "Registered %r event to execute %r", event_handler.event, event_handler.handler
+            "Registered %r event to execute handler %r",
+            event_handler.event,
+            event_handler.handler.__name__,
         )
 
     def remove_event_handler(self, event_handler: events.TSEventHandler) -> None:
-        self.event_handlers[event_handler.event].remove(event_handler)
+        self._event_handlers[event_handler.event].remove(event_handler)
 
-        if not self.event_handlers[event_handler.event]:
-            del self.event_handlers[event_handler.event]
+        if not self._event_handlers[event_handler.event]:
+            del self._event_handlers[event_handler.event]

--- a/tsbot/parsers.py
+++ b/tsbot/parsers.py
@@ -5,11 +5,11 @@ from tsbot import encoders
 KWARG_INDICATOR = "-"
 
 
-def parse_data(input_str: str) -> list[dict[str, str]]:
+def parse_data(input_str: str) -> tuple[dict[str, str], ...]:
     if not input_str:
-        return []
+        return tuple()
 
-    return list(map(parse_line, input_str.split("|")))
+    return tuple(map(parse_line, input_str.split("|")))
 
 
 def parse_line(input_str: str) -> dict[str, str]:
@@ -24,7 +24,7 @@ def parse_value(input_str: str) -> tuple[str, str]:
 
     if "|" in value:
         # Multiple values associated with the key. Making values comma separated
-        return key, ",".join(v for v in value.split(f"|{key}="))
+        return key, ",".join(map(encoders.unescape, value.split(f"|{key}=")))
 
     return key, encoders.unescape(value) if value else ""
 

--- a/tsbot/response.py
+++ b/tsbot/response.py
@@ -14,7 +14,7 @@ class TSResponse:
     Class to represent the response to a query from a Teamspeak server.
     """
 
-    data: list[dict[str, str]]
+    data: tuple[dict[str, str], ...]
     error_id: int
     msg: str
 
@@ -40,6 +40,6 @@ class TSResponse:
         msg = response_info.pop("msg")
 
         if response_info:
-            data.append(response_info)
+            data += (response_info,)
 
         return cls(data=data, error_id=error_id, msg=msg)

--- a/tsbot/utils.py
+++ b/tsbot/utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import itertools
+from contextlib import contextmanager
+from typing import Any
+
+
+@contextmanager
+def toggle(obj: object, attr: str, enter: Any, exit: Any):
+    setattr(obj, attr, enter)
+    try:
+        yield
+    finally:
+        setattr(obj, attr, exit)
+
+
+def pop_traceback(exception: Exception, amount: int = 1) -> Exception:
+    tb, count = exception.__traceback__, itertools.count()
+
+    while tb and next(count) < amount:
+        tb = tb.tb_next
+
+    return exception.with_traceback(tb)

--- a/tsbot/utils.py
+++ b/tsbot/utils.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import itertools
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Generator
 
 
 @contextmanager
-def toggle(obj: object, attr: str, enter: Any, exit: Any):
+def toggle(obj: object, attr: str, enter: Any, exit: Any) -> Generator[None, None, None]:
     setattr(obj, attr, enter)
     try:
         yield


### PR DESCRIPTION
# Breaking:
## `bot.close()` method no longer async
Closing the bot no longer needs to be awaited.
This API was kinda awkward when calling outside the event loop, for example in a signal handler.
There wasn't any need to await the bot to actually close, just star the closing process.

### Migration guide:
change `await bot.close()` to `bot.close()`

# Other changes

- More graceful closing handling.
- TSResponse data from `list` to `tuple`.
- Private bot internals.
- `bot.get_command_handler()` method.